### PR TITLE
Remove apicast-cli from main rockspec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     working_directory: /opt/app-root/wildcard_service
     steps:
       - checkout
-      - run: luarocks make *.rockspec
+      - run: luarocks make wildcard-service-scm-0.rockspec
       - run: /usr/local/openresty/luajit/bin/apicast-cli busted
       - run: prove
       - store_artifacts:

--- a/wildcard-service-scm-0.rockspec
+++ b/wildcard-service-scm-0.rockspec
@@ -1,0 +1,24 @@
+rockspec_format = "1.1"
+package = "wildcard-service"
+version = "scm-0"
+source = {
+   url = "*** please add URL for source tarball, zip or repository here ***"
+}
+description = {
+   summary = "*** please specify description summary ***",
+   detailed = "*** please specify description description ***",
+   homepage = "*** please specify description homepage ***",
+   license = "MIT"
+}
+dependencies = {
+   "apicast-cli == scm-1", "apicast == scm-1"
+}
+build = {
+   type = "builtin",
+   modules = {
+      ["wildcard-service.config.development"] = "config/development.lua",
+      ["wildcard-service.config.production"] = "config/production.lua",
+      ["wildcard-service.init"] = "src/wildcard-service/init.lua"
+   },
+   install = {}
+}

--- a/wildcard-service-scm-1.rockspec
+++ b/wildcard-service-scm-1.rockspec
@@ -11,7 +11,7 @@ description = {
    license = "MIT"
 }
 dependencies = {
-   "apicast-cli == scm-1", "apicast == scm-1"
+   "apicast == scm-1"
 }
 build = {
    type = "builtin",


### PR DESCRIPTION
`wildcard-service-scm-0.rockspec` is dev rockspec for now, `apicast-cli` needs to be productized. 